### PR TITLE
DI-809 - fix upload of output file to job destination

### DIFF
--- a/src/vcf_qc.py
+++ b/src/vcf_qc.py
@@ -281,13 +281,22 @@ def upload_output_file(outfile) -> None:
     outfile : str
         name of file to upload
     """
-    print(f"\nUploading {outfile}")
+    output_project = os.environ.get("DX_PROJECT_CONTEXT_ID")
+    output_folder = (
+        dxpy.bindings.dxjob.DXJob(os.environ.get("DX_JOB_ID"))
+        .describe()
+        .get("folder", "/")
+    )
+    print(f"\nUploading {outfile} to {output_project}:{output_folder}")
+
+    dxpy.set_workspace_id(output_project)
+    dxpy.api.project_new_folder(
+        output_project, input_params={"folder": output_folder, "parents": True}
+    )
 
     url_file = dxpy.upload_local_file(
         filename=outfile,
-        folder=dxpy.bindings.dxjob.DXJob(
-            os.environ.get("DX_JOB_ID")
-        ).describe()["folder"],
+        folder=output_folder,
         wait_on_close=True,
     )
 

--- a/tests/test_vcf_qc.py
+++ b/tests/test_vcf_qc.py
@@ -372,9 +372,10 @@ class TestWriteOutputFile(unittest.TestCase):
 
 
 @patch("src.vcf_qc.dxpy.upload_local_file")
+@patch("src.vcf_qc.dxpy.api.project_new_folder")
 @patch("src.vcf_qc.dxpy.bindings.dxjob.DXJob")
 class TestUploadOutputFile(unittest.TestCase):
-    def test_upload_params_correct(self, mock_job, mock_upload):
+    def test_upload_params_correct(self, mock_job, mock_folder, mock_upload):
         mock_job.return_value.describe.return_value = {
             "folder": "/output/sub_folder"
         }
@@ -389,7 +390,9 @@ class TestUploadOutputFile(unittest.TestCase):
 
         self.assertEqual(mock_upload.call_args[1], expected_args)
 
-    def test_expected_dxlink_format_returned(self, mock_job, mock_upload):
+    def test_expected_dxlink_format_returned(
+        self, mock_job, mock_folder, mock_upload
+    ):
         mock_upload.return_value = "file-xxx"
 
         self.assertEqual(


### PR DESCRIPTION
- fix the headache that is uploading files from Python apps when destination is set because they can't just handle creating the output folder location implicitly and make my life easy

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vcf_qc/15)
<!-- Reviewable:end -->
